### PR TITLE
fix: add buffer-length check in main.c

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -289,7 +289,7 @@ mainMenu:
 						{
 							if (strstr(ent->d_name, ".ter") != NULL)
 							{
-								strcpy(worldFiles[worldFileCount], ent->d_name);
+								snprintf(worldFiles[worldFileCount], sizeof(worldFiles[worldFileCount]), "%s", ent->d_name);
 								worldFileCount++;
 								if (worldFileCount >= 10)
 									break; // Max 10 worlds for now


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `source/main.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `source/main.c:292` |
| **Assessment** | Confirmed exploitable |
| **CWE** | CWE-120 |

**Description**: The application uses strcpy to copy directory entry names (ent->d_name) into a fixed-size buffer worldFiles[worldFileCount] without any bounds checking. If a filename in the world files directory exceeds the allocated buffer size, a stack or heap buffer overflow occurs, enabling arbitrary code execution.

## Changes
- `source/main.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
